### PR TITLE
rule-seq

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 /lib
 /classes
 /cssgen.jar
+/target
 /*.jar
 /pom.xml
 /multi-lib

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject cssgen "0.2.6"
+(defproject cssgen-rule-seq "0.2.7-SNAPSHOT"
   :description "Generate CSS from clojure code. Like an embedded sass."
   :url "http://github.com/paraseba/cssgen"
   :dependencies [[org.clojure/clojure "1.2.0"]

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject cssgen-rule-seq "0.2.7-SNAPSHOT"
+(defproject cssgen-rule-seq "0.2.8"
   :description "Generate CSS from clojure code. Like an embedded sass."
   :url "http://github.com/paraseba/cssgen"
   :dependencies [[org.clojure/clojure "1.2.0"]

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject cssgen-rule-seq "0.2.7-SNAPSHOT"
+(defproject cssgen "0.2.6"
   :description "Generate CSS from clojure code. Like an embedded sass."
   :url "http://github.com/paraseba/cssgen"
   :dependencies [[org.clojure/clojure "1.2.0"]

--- a/src/cssgen.clj
+++ b/src/cssgen.clj
@@ -87,3 +87,7 @@
 (defn css-file [path & rules]
   (spit path (apply css rules)))
 
+(defmacro rule-seq [& rules]
+  (let [name 'rule-sequence]
+    `(defonce ~name [~@rules])))
+

--- a/src/cssgen.clj
+++ b/src/cssgen.clj
@@ -87,7 +87,9 @@
 (defn css-file [path & rules]
   (spit path (apply css rules)))
 
-(defmacro rule-seq [& rules]
+(defmacro rule-seq
+  "Group a sequence of rules into a vector named rule-sequence."
+  [& rules]
   (let [name 'rule-sequence]
     `(defonce ~name [~@rules])))
 

--- a/test/rules.clj
+++ b/test/rules.clj
@@ -1,5 +1,6 @@
 (ns rules
-  (:use cssgen cssgen.types clojure.test))
+  (:use cssgen cssgen.types clojure.test)
+  (:import cssgen.Rule))
 
 (deftest single-prop-rules
   (are [the-rule result] (= result (css the-rule))
@@ -141,4 +142,13 @@ tr td {
   font-size: 2mm;
 }
 "))
+
+
+(deftest rule-sequence-formation
+  (rule-seq
+   (rule "a")
+   (rule "div"))  
+  (is (= [(Rule. "a" [] [])
+          (Rule. "div" [] [])]
+           rule-sequence)))
 

--- a/test/rules.clj
+++ b/test/rules.clj
@@ -143,7 +143,6 @@ tr td {
 }
 "))
 
-
 (deftest rule-sequence-formation
   (rule-seq
    (rule "a")


### PR DESCRIPTION
Added a rule-seq macro that groups rules into a vector named rule-sequence.

The purpose of having such a macro is that it will provide the necessary hook for a Leiningen plugin to generate CSS files. I have already begun [the project](https://github.com/MichaelDrogalis/lein-cssgenbuild). Anyone using this plugin, however, must also use the fork I made of cssgen which contains the rule-seq macro. It would be ideal to merge the macro into cssgen's core so that users of the Lein plugin can simply use the original cssgen dependency.

FYI, feature to watch files and generate CSS files on modification is on the way. :)
